### PR TITLE
Added jpeg extension in getImageType

### DIFF
--- a/ImageTool.php
+++ b/ImageTool.php
@@ -611,6 +611,7 @@ class ImageTool {
 		if ($extension) {
 			switch (self::getExtension($input)) {
 				case 'jpg':
+				case 'jpeg':
 					return 'jpg';
 				break;
 


### PR DESCRIPTION
If an upload would occur and the extension was jpeg, which is valid,
nothing would occur as it could not recognize the image type.
